### PR TITLE
Optional ability to use higher quality images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-error.log*
 backend/*/bin
 backend/*/obj
 backend/Images/*.jpg
+backend/Images/*.webp

--- a/backend/Discapp.API/Controllers/QueueController.cs
+++ b/backend/Discapp.API/Controllers/QueueController.cs
@@ -5,52 +5,70 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Discapp.API.Controllers
 {
-    [ApiController]
-    [Route("api/[controller]")]
-    public class QueueController : ControllerBase
-    {
-        private readonly ApplicationDbContext _context;
-        private readonly PathSettings _pathSettings;
+	[ApiController]
+	[Route("api/[controller]")]
+	public class QueueController : ControllerBase
+	{
+		private readonly ApplicationDbContext _context;
+		private readonly PathSettings _pathSettings;
 
-        public QueueController(ApplicationDbContext context, PathSettings pathSettings)
-        {
-            _context = context;
-            _pathSettings = pathSettings;
-        }
+		public QueueController(ApplicationDbContext context, PathSettings pathSettings)
+		{
+			_context = context;
+			_pathSettings = pathSettings;
+		}
 
-        [HttpPost]
-        public async Task<ActionResult<RecordReply>> PostMyEntity(int[] input)
-        {
-            RecordReply records = new();
+		[HttpPost]
+		public async Task<ActionResult<RecordReply>> PostMyEntity(int[] input)
+		{
+			RecordReply records = new();
 
-            foreach (int recordId in input)
+			foreach (int recordId in input)
+			{
+				Record? record = await _context.Records.FirstOrDefaultAsync(r => r.RecordID == recordId);
+
+				if (record != null)
+				{
+					records.Available.Add(new()
+					{
+						RecordID = record.RecordID,
+						Image = GetImage(record.RecordID.ToString(), "thumb", "jpg") ?? "",
+                        ImageHigh = GetImage(record.RecordID.ToString(), "w3", "webp") ?? "",
+						Barcode = record.Barcode
+					});
+				}
+				else
+				{
+					Queue myEntity = new() { RecordID = recordId };
+					_context.Queue.Add(myEntity);
+					records.Queued.Add(recordId);
+				}
+			}
+
+			await _context.SaveChangesAsync();
+
+			return Ok(records);
+		}
+
+		private string? GetImage(string recordID, string type, string format)
+		{
+			var mimeTypes = new Dictionary<string, string>
             {
-                Record? record = await _context.Records.FirstOrDefaultAsync(r => r.RecordID == recordId);
+                { "jpg", "image/jpeg" },
+                { "webp", "image/webp" },
+            };
 
-                if (record != null)
-                {
-                    string fullPath = Path.Combine(_pathSettings.ImagePath, record.RecordID.ToString() + "_thumb.jpg");
-                    byte[] fileBytes = System.IO.File.ReadAllBytes(fullPath);
-                    string base64String = Convert.ToBase64String(fileBytes);
+			string fullPath = Path.Combine(_pathSettings.ImagePath, $"{recordID}_{type.ToLower()}.{format.ToLower()}");
 
-                    records.Available.Add(new()
-                    {
-                        RecordID = record.RecordID,
-                        Image = $"data:image/jpeg;base64,{base64String}",
-                        Barcode = record.Barcode
-                    });
-                }
-                else
-                {
-                    Queue myEntity = new() { RecordID = recordId };
-                    _context.Queue.Add(myEntity);
-                    records.Queued.Add(recordId);
-                }
-            }
+			if (!System.IO.File.Exists(fullPath))
+			{
+				return null;
+			}
 
-            await _context.SaveChangesAsync();
-
-            return Ok(records);
-        }
-    }
+			byte[] fileBytes = System.IO.File.ReadAllBytes(fullPath);
+			string base64String = Convert.ToBase64String(fileBytes);
+			string mimeType = mimeTypes[format.ToLower()];
+            return $"data:{mimeType};base64,{base64String}";
+		}
+	}
 }

--- a/backend/Discapp.API/Models/AvailableRecord.cs
+++ b/backend/Discapp.API/Models/AvailableRecord.cs
@@ -4,6 +4,7 @@ namespace Discapp.API.Models
     {
         public int RecordID { get; set; }
         public string Image { get; set; } = "";
+        public string ImageHigh { get; set; } = "";
         public string Barcode { get; set; } = "";
     }
 }

--- a/backend/Discapp.Worker/Discapp.Worker.csproj
+++ b/backend/Discapp.Worker/Discapp.Worker.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="MySql.EntityFrameworkCore" Version="8.0.5" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
   </ItemGroup>
 

--- a/backend/Discapp.Worker/Models/DiscogsImages.cs
+++ b/backend/Discapp.Worker/Models/DiscogsImages.cs
@@ -1,0 +1,7 @@
+namespace Discapp.Worker.Models;
+
+public class DiscogsImages
+{
+    public string Type { get; set; } = "";
+    public string Uri { get; set; } = "";
+}

--- a/backend/Discapp.Worker/Models/DiscogsRelease.cs
+++ b/backend/Discapp.Worker/Models/DiscogsRelease.cs
@@ -4,4 +4,5 @@ public class DiscogsRelease
 {
     public string Thumb { get; set; } = "";
     public List<DiscogReleaseIdentifiers> Identifiers { get; set; } = [];
+    public List<DiscogsImages> Images { get; set; } = [];
 }

--- a/backend/Discapp.Worker/Worker.cs
+++ b/backend/Discapp.Worker/Worker.cs
@@ -3,168 +3,196 @@ using Discapp.Shared.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using System.Net.Http.Json;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.Formats.Webp;
+using System.IO;
 
 namespace Discapp.Worker;
 
 public class Worker : BackgroundService
 {
-    private readonly ILogger<Worker> _logger;
-    private readonly IServiceScopeFactory _scopeFactory;
-    private readonly DiscogsOptions _discogsOptions;
-    private readonly PathSettings _pathOptions;
-    private readonly HttpClient _httpClient;
+	private readonly ILogger<Worker> _logger;
+	private readonly IServiceScopeFactory _scopeFactory;
+	private readonly DiscogsOptions _discogsOptions;
+	private readonly PathSettings _pathOptions;
+	private readonly HttpClient _httpClient;
 
-    public Worker(ILogger<Worker> logger, IServiceScopeFactory scopeFactory, IOptions<DiscogsOptions> discogsOptions, IOptions<PathSettings> pathOptions)
-    {
-        _logger = logger;
-        _scopeFactory = scopeFactory;
-        _discogsOptions = discogsOptions.Value;
-        _pathOptions = pathOptions.Value;
-        _httpClient = new HttpClient
-        {
-            BaseAddress = new Uri("https://api.discogs.com/")
-        };
-        _httpClient.DefaultRequestHeaders.Add("User-Agent", "DiscappWorker/1.0");
-        _httpClient.DefaultRequestHeaders.Add("Authorization", $"Discogs key={_discogsOptions.ConsumerKey}, secret={_discogsOptions.ConsumerSecret}");
-    }
+	public Worker(ILogger<Worker> logger, IServiceScopeFactory scopeFactory, IOptions<DiscogsOptions> discogsOptions, IOptions<PathSettings> pathOptions)
+	{
+		_logger = logger;
+		_scopeFactory = scopeFactory;
+		_discogsOptions = discogsOptions.Value;
+		_pathOptions = pathOptions.Value;
+		_httpClient = new HttpClient
+		{
+			BaseAddress = new Uri("https://api.discogs.com/")
+		};
+		_httpClient.DefaultRequestHeaders.Add("User-Agent", "DiscappWorker/1.0");
+		_httpClient.DefaultRequestHeaders.Add("Authorization", $"Discogs key={_discogsOptions.ConsumerKey}, secret={_discogsOptions.ConsumerSecret}");
+	}
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
-    {
-        while (!stoppingToken.IsCancellationRequested)
-        {
-            if (_logger.IsEnabled(LogLevel.Information))
-            {
-                _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+	{
+		while (!stoppingToken.IsCancellationRequested)
+		{
+			if (_logger.IsEnabled(LogLevel.Information))
+			{
+				_logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
 
-                using IServiceScope scope = _scopeFactory.CreateScope();
+				using IServiceScope scope = _scopeFactory.CreateScope();
 
-                ApplicationDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+				ApplicationDbContext dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
-                await FilterOldRecords(dbContext, stoppingToken);
+				await FilterOldRecords(dbContext, stoppingToken);
 
-                await ProcessQueue(dbContext, stoppingToken);
-            }
-            await Task.Delay(1000, stoppingToken);
-        }
-    }
+				await ProcessQueue(dbContext, stoppingToken);
+			}
+			await Task.Delay(1000, stoppingToken);
+		}
+	}
 
-    private async Task ProcessQueue(ApplicationDbContext dbContext, CancellationToken stoppingToken)
-    {
-        Queue? queueItem = await dbContext.Queue.FirstOrDefaultAsync(stoppingToken);
+	private async Task ProcessQueue(ApplicationDbContext dbContext, CancellationToken stoppingToken)
+	{
+		Queue? queueItem = await dbContext.Queue.FirstOrDefaultAsync(stoppingToken);
 
-        if (queueItem != null)
-        {
-            try
-            {
-                HttpResponseMessage response = await GetApiResponseWithRetryAsync($"releases/{queueItem.RecordID.ToString()}", 3, 1000, stoppingToken);
-                response.EnsureSuccessStatusCode();
+		if (queueItem != null)
+		{
+			try
+			{
+				HttpResponseMessage response = await GetApiResponseWithRetryAsync($"releases/{queueItem.RecordID.ToString()}", 3, 1000, stoppingToken);
+				response.EnsureSuccessStatusCode();
 
-                DiscogsRelease? releaseData = await response.Content.ReadFromJsonAsync<DiscogsRelease>();
+				DiscogsRelease? releaseData = await response.Content.ReadFromJsonAsync<DiscogsRelease>();
 
-                if (!string.IsNullOrEmpty(releaseData?.Thumb))
-                {
-                    string imageUrl = releaseData.Thumb;
-                    byte[] imageBytes = await GetApiResponseWithRetryAsync(imageUrl, 3, 1000, stoppingToken).Result.Content.ReadAsByteArrayAsync(stoppingToken);
+				if (!string.IsNullOrEmpty(releaseData?.Thumb))
+				{
+					string imageUrl = releaseData.Thumb;
+					byte[] imageBytes = await GetApiResponseWithRetryAsync(imageUrl, 3, 1000, stoppingToken).Result.Content.ReadAsByteArrayAsync(stoppingToken);
 
-                    string filePath = Path.Combine(_pathOptions.ImagePath, queueItem.RecordID.ToString() + "_thumb.jpg");
-                    await File.WriteAllBytesAsync(filePath, imageBytes, stoppingToken);
+					string filePath = Path.Combine(_pathOptions.ImagePath, queueItem.RecordID.ToString() + "_thumb.jpg");
+					await File.WriteAllBytesAsync(filePath, imageBytes, stoppingToken);
 
-                    string recordBarcode = releaseData.Identifiers
-                        .Where(id => id.Type == "Barcode")
-                        .Select(id => id.Value.Replace(" ", ""))
-                        .FirstOrDefault() ?? "";
+					string recordBarcode = releaseData.Identifiers
+						.Where(id => id.Type == "Barcode")
+						.Select(id => id.Value.Replace(" ", ""))
+						.FirstOrDefault() ?? "";
 
-                    Record? existingRecord = await dbContext.Records
-                        .FirstOrDefaultAsync(r => r.RecordID == queueItem.RecordID, stoppingToken);
+					string mainCoverUri = releaseData.Images
+						.Where(id => id.Type.ToLower() == "primary")
+						.Select(id => id.Uri)
+						.FirstOrDefault() ?? "";
+					if (!string.IsNullOrEmpty(mainCoverUri))
+					{
+						byte[] mainCover = await GetApiResponseWithRetryAsync(mainCoverUri, 3, 1000, stoppingToken).Result.Content.ReadAsByteArrayAsync(stoppingToken);
+						byte[] conversionOut = await ConvertImage(mainCover, 300, 300);
+						await File.WriteAllBytesAsync(Path.Combine(_pathOptions.ImagePath, queueItem.RecordID.ToString() + "_w3.webp"), conversionOut);
+					}
 
-                    if (existingRecord != null)
-                    {
-                        existingRecord.Recorded = DateTime.Now;
-                        dbContext.Records.Update(existingRecord);
-                    }
-                    else
-                    {
-                        Record newRecord = new()
-                        {
-                            RecordID = queueItem.RecordID,
-                            Barcode = recordBarcode,
-                            Recorded = DateTime.Now
-                        };
-                        dbContext.Records.Add(newRecord);
-                    }
+					Record? existingRecord = await dbContext.Records
+						.FirstOrDefaultAsync(r => r.RecordID == queueItem.RecordID, stoppingToken);
 
-                    dbContext.Queue.Remove(queueItem);
-                    await dbContext.SaveChangesAsync(stoppingToken);
+					if (existingRecord != null)
+					{
+						existingRecord.Recorded = DateTime.Now;
+						dbContext.Records.Update(existingRecord);
+					}
+					else
+					{
+						Record newRecord = new()
+						{
+							RecordID = queueItem.RecordID,
+							Barcode = recordBarcode,
+							Recorded = DateTime.Now
+						};
+						dbContext.Records.Add(newRecord);
+					}
 
-                    _logger.LogInformation($"Processed and removed Queue item with ID {queueItem.Id}, saved image to {filePath}");
-                }
-                else
-                {
-                    _logger.LogWarning($"No thumbnail found for release ID {queueItem.RecordID}");
-                    dbContext.Queue.Remove(queueItem);
-                    await dbContext.SaveChangesAsync(stoppingToken);
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"An error occurred while processing the queue ID {queueItem.Id}.");
-                dbContext.Queue.Remove(queueItem);
-                await dbContext.SaveChangesAsync(stoppingToken);
-            }
-        }
-        else
-        {
-            _logger.LogInformation("Nothing in the queue.");
-        }
-    }
+					dbContext.Queue.Remove(queueItem);
+					await dbContext.SaveChangesAsync(stoppingToken);
 
-    private async Task FilterOldRecords(ApplicationDbContext dbContext, CancellationToken stoppingToken)
-    {
-        DateTime decay = DateTime.Now.AddMonths(-3);
-        List<Record> oldRecords = await dbContext.Records
-            .Where(r => r.Recorded < decay)
-            .ToListAsync(stoppingToken);
+					_logger.LogInformation($"Processed and removed Queue item with ID {queueItem.Id}, saved image to {filePath}");
+				}
+				else
+				{
+					_logger.LogWarning($"No thumbnail found for release ID {queueItem.RecordID}");
+					dbContext.Queue.Remove(queueItem);
+					await dbContext.SaveChangesAsync(stoppingToken);
+				}
+			}
+			catch (Exception ex)
+			{
+				_logger.LogError(ex, $"An error occurred while processing the queue ID {queueItem.Id}.");
+				dbContext.Queue.Remove(queueItem);
+				await dbContext.SaveChangesAsync(stoppingToken);
+			}
+		}
+		else
+		{
+			_logger.LogInformation("Nothing in the queue.");
+		}
+	}
 
-        if (oldRecords.Count > 0)
-        {
-            foreach (Record oldRecord in oldRecords)
-            {
-                bool isAlreadyInQueue = await dbContext.Queue
-                    .AnyAsync(q => q.RecordID == oldRecord.RecordID, stoppingToken);
+	private async Task FilterOldRecords(ApplicationDbContext dbContext, CancellationToken stoppingToken)
+	{
+		DateTime decay = DateTime.Now.AddMonths(-3);
+		List<Record> oldRecords = await dbContext.Records
+			.Where(r => r.Recorded < decay)
+			.ToListAsync(stoppingToken);
 
-                if (!isAlreadyInQueue)
-                {
-                    Queue newQueueItem = new()
-                    {
-                        RecordID = oldRecord.RecordID
-                    };
-                    dbContext.Queue.Add(newQueueItem);
-                }
-            }
-            await dbContext.SaveChangesAsync(stoppingToken);
-            _logger.LogInformation($"Checked {oldRecords.Count} old records and added them to the queue if not already present.");
-        }
-    }
+		if (oldRecords.Count > 0)
+		{
+			foreach (Record oldRecord in oldRecords)
+			{
+				bool isAlreadyInQueue = await dbContext.Queue
+					.AnyAsync(q => q.RecordID == oldRecord.RecordID, stoppingToken);
 
-    private async Task<HttpResponseMessage> GetApiResponseWithRetryAsync(string requestUri, int maxRetries, int delayMilliseconds, CancellationToken stoppingToken)
-    {
-        int retryCount = 0;
-        while (retryCount < maxRetries)
-        {
-            HttpResponseMessage response = await _httpClient.GetAsync(requestUri, stoppingToken);
-            if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
-            {
-                _logger.LogWarning("Received 429 Too Many Requests. Retrying after delay...");
-                await Task.Delay(delayMilliseconds);
-                retryCount++;
-                delayMilliseconds += 1000; // Exponential backoff
-            }
-            else
-            {
-                response.EnsureSuccessStatusCode();
-                return response;
-            }
-        }
-        throw new HttpRequestException("Maximum retry attempts exceeded.");
-    }
+				if (!isAlreadyInQueue)
+				{
+					Queue newQueueItem = new()
+					{
+						RecordID = oldRecord.RecordID
+					};
+					dbContext.Queue.Add(newQueueItem);
+				}
+			}
+			await dbContext.SaveChangesAsync(stoppingToken);
+			_logger.LogInformation($"Checked {oldRecords.Count} old records and added them to the queue if not already present.");
+		}
+	}
+
+	private async Task<HttpResponseMessage> GetApiResponseWithRetryAsync(string requestUri, int maxRetries, int delayMilliseconds, CancellationToken stoppingToken)
+	{
+		int retryCount = 0;
+		while (retryCount < maxRetries)
+		{
+			HttpResponseMessage response = await _httpClient.GetAsync(requestUri, stoppingToken);
+			if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+			{
+				_logger.LogWarning("Received 429 Too Many Requests. Retrying after delay...");
+				await Task.Delay(delayMilliseconds);
+				retryCount++;
+				delayMilliseconds += 1000; // Exponential backoff
+			}
+			else
+			{
+				response.EnsureSuccessStatusCode();
+				return response;
+			}
+		}
+		throw new HttpRequestException("Maximum retry attempts exceeded.");
+	}
+
+	private async static Task<byte[]> ConvertImage(byte[] inputImageBytes, int width, int height)
+	{
+		using (Image image = Image.Load(inputImageBytes))
+		{
+			image.Mutate(x => x.Resize(width, height));
+			using (var outputStream = new MemoryStream())
+			{
+				await image.SaveAsync(outputStream, new WebpEncoder());
+				return outputStream.ToArray();
+			}
+		}
+	}
 }

--- a/frontend/src/api/discogs.ts
+++ b/frontend/src/api/discogs.ts
@@ -31,6 +31,7 @@ export const getProfile = async (username: string, password: string): Promise<IP
 export const getCollectionWants = async (
 	username: string,
 	password: string,
+	imageQuality: boolean,
 	onProgress?: (page: number, pages: number) => void
 ): Promise<IReleases[]> => {
 	let allReleases: IReleases[] = []
@@ -67,7 +68,7 @@ export const getCollectionWants = async (
 					const imageData = await secondaryResponse.json()
 
 					imageMap = imageData.available.reduce((acc: Record<number, VinylAPIImageMap>, record: any) => {
-						acc[record.recordID] = { image: record.image, barcode: record.barcode }
+						acc[record.recordID] = { image: record.image, imageHigh: record.imageHigh, barcode: record.barcode }
 						return acc
 					}, {})
 				} else {
@@ -80,10 +81,10 @@ export const getCollectionWants = async (
 
 		// @ts-expect-error Cheating a bit - converting the reference to keep the same models.
 		const releasesExtraData = data.wants.map((release) => {
-			const imageRecord = imageMap[release.basic_information.id] || { image: null, barcode: null }
+			const imageRecord = imageMap[release.basic_information.id] || { image: null, imageHigh: null, barcode: null }
 			return {
 				...release,
-				image_base64: imageRecord.image,
+				image_base64: (imageQuality) ? (imageRecord.imageHigh !== null ? imageRecord.imageHigh : imageRecord.image) : imageRecord.image,
 				barcode: imageRecord.barcode,
 			}
 		})
@@ -104,6 +105,7 @@ export const getCollectionWants = async (
 export const getCollectionReleases = async (
 	username: string,
 	password: string,
+	imageQuality: boolean,
 	onProgress?: (page: number, pages: number) => void
 ): Promise<IReleases[]> => {
 	let allReleases: IReleases[] = []
@@ -139,7 +141,7 @@ export const getCollectionReleases = async (
 					const imageData = await secondaryResponse.json()
 
 					imageMap = imageData.available.reduce((acc: Record<number, VinylAPIImageMap>, record: any) => {
-						acc[record.recordID] = { image: record.image, barcode: record.barcode }
+						acc[record.recordID] = { image: record.image, imageHigh: record.imageHigh, barcode: record.barcode }
 						return acc
 					}, {})
 				} else {
@@ -151,10 +153,10 @@ export const getCollectionReleases = async (
 		}
 
 		const releasesExtraData = data.releases.map((release) => {
-			const imageRecord = imageMap[release.basic_information.id] || { image: null, barcode: null }
+			const imageRecord = imageMap[release.basic_information.id] || { image: null, imageHigh: null, barcode: null }
 			return {
 				...release,
-				image_base64: imageRecord.image,
+				image_base64: (imageQuality) ? (imageRecord.imageHigh !== null ? imageRecord.imageHigh : imageRecord.image) : imageRecord.image,
 				barcode: imageRecord.barcode,
 			}
 		})

--- a/frontend/src/api/discogs.ts
+++ b/frontend/src/api/discogs.ts
@@ -68,7 +68,11 @@ export const getCollectionWants = async (
 					const imageData = await secondaryResponse.json()
 
 					imageMap = imageData.available.reduce((acc: Record<number, VinylAPIImageMap>, record: any) => {
-						acc[record.recordID] = { image: record.image, imageHigh: record.imageHigh, barcode: record.barcode }
+						acc[record.recordID] = {
+							image: record.image,
+							imageHigh: record.imageHigh,
+							barcode: record.barcode,
+						}
 						return acc
 					}, {})
 				} else {
@@ -81,10 +85,18 @@ export const getCollectionWants = async (
 
 		// @ts-expect-error Cheating a bit - converting the reference to keep the same models.
 		const releasesExtraData = data.wants.map((release) => {
-			const imageRecord = imageMap[release.basic_information.id] || { image: null, imageHigh: null, barcode: null }
+			const imageRecord = imageMap[release.basic_information.id] || {
+				image: null,
+				imageHigh: null,
+				barcode: null,
+			}
 			return {
 				...release,
-				image_base64: (imageQuality) ? (imageRecord.imageHigh !== null ? imageRecord.imageHigh : imageRecord.image) : imageRecord.image,
+				image_base64: imageQuality
+					? imageRecord.imageHigh !== null
+						? imageRecord.imageHigh
+						: imageRecord.image
+					: imageRecord.image,
 				barcode: imageRecord.barcode,
 			}
 		})
@@ -141,7 +153,11 @@ export const getCollectionReleases = async (
 					const imageData = await secondaryResponse.json()
 
 					imageMap = imageData.available.reduce((acc: Record<number, VinylAPIImageMap>, record: any) => {
-						acc[record.recordID] = { image: record.image, imageHigh: record.imageHigh, barcode: record.barcode }
+						acc[record.recordID] = {
+							image: record.image,
+							imageHigh: record.imageHigh,
+							barcode: record.barcode,
+						}
 						return acc
 					}, {})
 				} else {
@@ -153,10 +169,18 @@ export const getCollectionReleases = async (
 		}
 
 		const releasesExtraData = data.releases.map((release) => {
-			const imageRecord = imageMap[release.basic_information.id] || { image: null, imageHigh: null, barcode: null }
+			const imageRecord = imageMap[release.basic_information.id] || {
+				image: null,
+				imageHigh: null,
+				barcode: null,
+			}
 			return {
 				...release,
-				image_base64: (imageQuality) ? (imageRecord.imageHigh !== null ? imageRecord.imageHigh : imageRecord.image) : imageRecord.image,
+				image_base64: imageQuality
+					? imageRecord.imageHigh !== null
+						? imageRecord.imageHigh
+						: imageRecord.image
+					: imageRecord.image,
 				barcode: imageRecord.barcode,
 			}
 		})

--- a/frontend/src/api/discogs.ts
+++ b/frontend/src/api/discogs.ts
@@ -1,3 +1,4 @@
+import { isNullOrBlank } from "../utils"
 import { ICollections, IIdentify, IProfile, IReleases, VinylAPIImageMap } from "./interface"
 
 const API_URL = "https://api.discogs.com"
@@ -93,7 +94,7 @@ export const getCollectionWants = async (
 			return {
 				...release,
 				image_base64: imageQuality
-					? imageRecord.imageHigh !== null
+					? !isNullOrBlank(imageRecord.imageHigh)
 						? imageRecord.imageHigh
 						: imageRecord.image
 					: imageRecord.image,
@@ -177,7 +178,7 @@ export const getCollectionReleases = async (
 			return {
 				...release,
 				image_base64: imageQuality
-					? imageRecord.imageHigh !== null
+					? !isNullOrBlank(imageRecord.imageHigh)
 						? imageRecord.imageHigh
 						: imageRecord.image
 					: imageRecord.image,

--- a/frontend/src/api/interface.ts
+++ b/frontend/src/api/interface.ts
@@ -118,5 +118,6 @@ export interface IVinylResponse {
 
 export interface VinylAPIImageMap {
 	image?: string
+	imageHigh?: string
 	barcode?: string
 }

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { default as useAuth } from "./useAuth"
+export { default as useSettings } from "./useSettings"

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -1,15 +1,15 @@
 import { useState } from "react"
 
-const getLocalStorageItem = <T,>(key: string): T | null => {
+const getLocalStorageItem = <T>(key: string): T | null => {
 	const item = localStorage.getItem(key)
 	return item ? JSON.parse(item) : null
 }
 
-const setLocalStorageItem = <T,>(key: string, value: T): void => {
+const setLocalStorageItem = <T>(key: string, value: T): void => {
 	localStorage.setItem(key, JSON.stringify(value))
 }
 
-const useSettings = <T,>(key: string, defaultValue: T): [T, (value: T) => void, () => void] => {
+const useSettings = <T>(key: string, defaultValue: T): [T, (value: T) => void, () => void] => {
 	const [setting, setSetting] = useState<T>(() => {
 		const storedValue = getLocalStorageItem<T>(key)
 		return storedValue !== null ? storedValue : defaultValue

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -1,0 +1,31 @@
+import { useState } from "react"
+
+const getLocalStorageItem = <T,>(key: string): T | null => {
+	const item = localStorage.getItem(key)
+	return item ? JSON.parse(item) : null
+}
+
+const setLocalStorageItem = <T,>(key: string, value: T): void => {
+	localStorage.setItem(key, JSON.stringify(value))
+}
+
+const useSettings = <T,>(key: string, defaultValue: T): [T, (value: T) => void, () => void] => {
+	const [setting, setSetting] = useState<T>(() => {
+		const storedValue = getLocalStorageItem<T>(key)
+		return storedValue !== null ? storedValue : defaultValue
+	})
+
+	const saveSetting = (value: T): void => {
+		setLocalStorageItem(key, value)
+		setSetting(value)
+	}
+
+	const clearSetting = (): void => {
+		localStorage.removeItem(key)
+		setSetting(defaultValue)
+	}
+
+	return [setting, saveSetting, clearSetting]
+}
+
+export default useSettings

--- a/frontend/src/modal/Settings.tsx
+++ b/frontend/src/modal/Settings.tsx
@@ -38,7 +38,7 @@ const Settings: React.FC<Props> = ({ open, hasUpdate, onClose, onSave }) => {
 	const [newUsername, setNewUsername] = useState<string>(username ?? "")
 	const [newPassword, setNewPassword] = useState<string>(token ?? "")
 	const [storageInfo, setStorageInfo] = useState<{ usage: string; quota: string } | undefined>()
-	const [imageQuality, setImageQuality, clearImagequality] = useSettings<boolean>('ImagesAreHQ', false)
+	const [imageQuality, setImageQuality, clearImagequality] = useSettings<boolean>("ImagesAreHQ", false)
 	const appVersion = import.meta.env.VITE_VER ?? "Unknown"
 
 	useEffect(() => {
@@ -126,7 +126,9 @@ const Settings: React.FC<Props> = ({ open, hasUpdate, onClose, onSave }) => {
 				</IonNote>
 				<IonList inset={true}>
 					<IonItem>
-						<IonToggle checked={imageQuality} onIonChange={(e) => setImageQuality(e.detail.checked)}>Increase image quality</IonToggle>
+						<IonToggle checked={imageQuality} onIonChange={(e) => setImageQuality(e.detail.checked)}>
+							Increase image quality
+						</IonToggle>
 					</IonItem>
 				</IonList>
 				<IonNote color="medium" class="ion-margin-horizontal" style={{ display: "block" }}>

--- a/frontend/src/modal/Settings.tsx
+++ b/frontend/src/modal/Settings.tsx
@@ -18,9 +18,10 @@ import {
 	IonGrid,
 	IonRow,
 	IonAlert,
+	IonToggle,
 } from "@ionic/react"
 import { useQueryClient } from "@tanstack/react-query"
-import { useAuth } from "../hooks"
+import { useAuth, useSettings } from "../hooks"
 import { formatBytes } from "../utils"
 import { IReleases } from "../api"
 
@@ -37,6 +38,7 @@ const Settings: React.FC<Props> = ({ open, hasUpdate, onClose, onSave }) => {
 	const [newUsername, setNewUsername] = useState<string>(username ?? "")
 	const [newPassword, setNewPassword] = useState<string>(token ?? "")
 	const [storageInfo, setStorageInfo] = useState<{ usage: string; quota: string } | undefined>()
+	const [imageQuality, setImageQuality, clearImagequality] = useSettings<boolean>('ImagesAreHQ', false)
 	const appVersion = import.meta.env.VITE_VER ?? "Unknown"
 
 	useEffect(() => {
@@ -62,8 +64,9 @@ const Settings: React.FC<Props> = ({ open, hasUpdate, onClose, onSave }) => {
 	}
 
 	const deleteData = () => {
-		saveAuth("", "")
 		queryClient.clear()
+		clearAuth()
+		clearImagequality()
 		window.location.reload()
 	}
 
@@ -120,6 +123,14 @@ const Settings: React.FC<Props> = ({ open, hasUpdate, onClose, onSave }) => {
 					Until OAuth is implemented, we currently use Access Token for authentication. To get your token,{" "}
 					<a href="https://www.discogs.com/settings/developers">visit the Developer page</a> and copy your
 					token, or click Generate if you do not have one.
+				</IonNote>
+				<IonList inset={true}>
+					<IonItem>
+						<IonToggle checked={imageQuality} onIonChange={(e) => setImageQuality(e.detail.checked)}>Increase image quality</IonToggle>
+					</IonItem>
+				</IonList>
+				<IonNote color="medium" class="ion-margin-horizontal" style={{ display: "block" }}>
+					If you have a large library, you may experience issues with this.
 				</IonNote>
 				<IonList inset={true}>
 					<IonItem>

--- a/frontend/src/pages/Collection.tsx
+++ b/frontend/src/pages/Collection.tsx
@@ -62,7 +62,7 @@ const filterActionButtons = [
 const CollectionPage: React.FC = () => {
 	const queryClient = useQueryClient()
 	const [present] = useIonActionSheet()
-	const [imageQuality, setImageQuality, clearImagequality] = useSettings<boolean>('ImagesAreHQ', false)
+	const [imageQuality, setImageQuality, clearImagequality] = useSettings<boolean>("ImagesAreHQ", false)
 	const [filter, setFilter] = useState<"release" | "label" | "artist" | "none">("none")
 	const [layout, setLayout] = useState<"grid" | "list">("grid")
 	const [modalInfo, setModalInfo] = useState<IReleases | undefined>(undefined)
@@ -120,14 +120,18 @@ const CollectionPage: React.FC = () => {
 	const collectionData = useQuery<IReleases[]>({
 		queryKey: [`${username}collection`],
 		queryFn: () =>
-			getCollectionReleases(username, token ?? "", imageQuality, (page, pages) => setLoading({ page: page, pages: pages })),
+			getCollectionReleases(username, token ?? "", imageQuality, (page, pages) =>
+				setLoading({ page: page, pages: pages })
+			),
 		staleTime: 1000 * 60 * 60 * 24, // 24 hours
 	})
 
 	const wantData = useQuery<IReleases[]>({
 		queryKey: [`${username}want`],
 		queryFn: () =>
-			getCollectionWants(username, token ?? "", imageQuality, (page, pages) => setLoading({ page: page, pages: pages })),
+			getCollectionWants(username, token ?? "", imageQuality, (page, pages) =>
+				setLoading({ page: page, pages: pages })
+			),
 		staleTime: 1000 * 60 * 60 * 24, // 24 hours
 	})
 

--- a/frontend/src/pages/Collection.tsx
+++ b/frontend/src/pages/Collection.tsx
@@ -21,7 +21,7 @@ import { filterOutline, personOutline, pricetagOutline, timeOutline, listOutline
 import { IReleases, getCollectionReleases, getCollectionWants } from "../api"
 import { FullpageLoading, AlbumGrid, FullpageInfo, AlbumListGroups } from "../components"
 import { ViewAlbumDetails } from "../modal"
-import { useAuth } from "../hooks"
+import { useAuth, useSettings } from "../hooks"
 import { masterSort } from "../utils"
 import { IReleaseTuple } from "../types"
 
@@ -62,6 +62,7 @@ const filterActionButtons = [
 const CollectionPage: React.FC = () => {
 	const queryClient = useQueryClient()
 	const [present] = useIonActionSheet()
+	const [imageQuality, setImageQuality, clearImagequality] = useSettings<boolean>('ImagesAreHQ', false)
 	const [filter, setFilter] = useState<"release" | "label" | "artist" | "none">("none")
 	const [layout, setLayout] = useState<"grid" | "list">("grid")
 	const [modalInfo, setModalInfo] = useState<IReleases | undefined>(undefined)
@@ -119,14 +120,14 @@ const CollectionPage: React.FC = () => {
 	const collectionData = useQuery<IReleases[]>({
 		queryKey: [`${username}collection`],
 		queryFn: () =>
-			getCollectionReleases(username, token ?? "", (page, pages) => setLoading({ page: page, pages: pages })),
+			getCollectionReleases(username, token ?? "", imageQuality, (page, pages) => setLoading({ page: page, pages: pages })),
 		staleTime: 1000 * 60 * 60 * 24, // 24 hours
 	})
 
 	const wantData = useQuery<IReleases[]>({
 		queryKey: [`${username}want`],
 		queryFn: () =>
-			getCollectionWants(username, token ?? "", (page, pages) => setLoading({ page: page, pages: pages })),
+			getCollectionWants(username, token ?? "", imageQuality, (page, pages) => setLoading({ page: page, pages: pages })),
 		staleTime: 1000 * 60 * 60 * 24, // 24 hours
 	})
 

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -23,7 +23,7 @@ interface IReleaseCollective {
 }
 
 const SearchPage: React.FC = () => {
-	const [imageQuality, setImageQuality, clearImagequality] = useSettings<boolean>('ImagesAreHQ', false)
+	const [imageQuality, setImageQuality, clearImagequality] = useSettings<boolean>("ImagesAreHQ", false)
 	const [searchTerm, setSearchTerm] = useState<string>("")
 	const [modalInfo, setModalInfo] = useState<{ data: IReleases; type: "collection" | "want" } | undefined>(undefined)
 	const [filterData, setFilterData] = useState<IReleaseCollective>({ collection: [], want: [] })

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -14,7 +14,7 @@ import { useQuery } from "@tanstack/react-query"
 import { IReleases, getCollectionReleases, getCollectionWants } from "../api"
 import { AlbumList, FullpageInfo, FullpageLoading } from "../components"
 import { BarcodeScanDialog, ViewAlbumDetails } from "../modal"
-import { useAuth } from "../hooks"
+import { useAuth, useSettings } from "../hooks"
 import { barcodeOutline } from "ionicons/icons"
 
 interface IReleaseCollective {
@@ -23,6 +23,7 @@ interface IReleaseCollective {
 }
 
 const SearchPage: React.FC = () => {
+	const [imageQuality, setImageQuality, clearImagequality] = useSettings<boolean>('ImagesAreHQ', false)
 	const [searchTerm, setSearchTerm] = useState<string>("")
 	const [modalInfo, setModalInfo] = useState<{ data: IReleases; type: "collection" | "want" } | undefined>(undefined)
 	const [filterData, setFilterData] = useState<IReleaseCollective>({ collection: [], want: [] })
@@ -43,13 +44,13 @@ const SearchPage: React.FC = () => {
 
 	const collectionData = useQuery<IReleases[]>({
 		queryKey: [`${username}collection`],
-		queryFn: () => getCollectionReleases(username, token ?? ""),
+		queryFn: () => getCollectionReleases(username, token ?? "", imageQuality),
 		staleTime: 1000 * 60 * 60 * 24, // 24 hours
 	})
 
 	const wantData = useQuery<IReleases[]>({
 		queryKey: [`${username}want`],
-		queryFn: () => getCollectionWants(username, token ?? ""),
+		queryFn: () => getCollectionWants(username, token ?? "", imageQuality),
 		staleTime: 1000 * 60 * 60 * 24, // 24 hours
 	})
 

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -24,3 +24,7 @@ export const formatBytes = (bytes: number, decimals: number = 2): string => {
 
 	return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i]
 }
+
+export const isNullOrBlank = (str: string | null | undefined): boolean => {
+	return !str || str.trim() === ""
+}


### PR DESCRIPTION
This makes the following changes:

## Backend

- The worker will get the primary image, convert to WebP, and compress to 300px.
- The API will serve these as an optional alongside the thumbnail.

## Frontend

- There's a new setting to enable saving HQ images.

This is optional as it doubles the size of space utilised, which can bring you closer to the device limit, causing instability. Otherwise, I've experienced no issues so far.